### PR TITLE
Feat: 워크스페이스 생성, 조회시 초대 코드도 함께 응답하도록 수정

### DIFF
--- a/src/workspaces/controllers/workspaces.controller.ts
+++ b/src/workspaces/controllers/workspaces.controller.ts
@@ -22,7 +22,7 @@ import { CreateWorkspaceDto } from '../dto/create-workspace.dto';
 import { UpdateWorkspaceDto } from '../dto/update-workspace.dto';
 import { UseInvitationCodeDto } from '../dto/use-invitation-code.dto';
 import { WorkspaceQueryDto } from '../dto/workspace-query.dto';
-import { findMyWorkspacesResponseDto, WorkspaceCreateResponseDto } from '../dto/workspace-response.dto';
+import { findMyWorkspacesResponseDto, findUserWorkspacesResponseDto, WorkspaceCreateResponseDto } from '../dto/workspace-response.dto';
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
 import { WorkspaceRole, WorkspaceUser } from '../entities/workspace-user.entity';
@@ -59,12 +59,12 @@ export class WorkspacesController {
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 목록이 성공적으로 조회되었습니다.',
-		type: findMyWorkspacesResponseDto,
+		type: findUserWorkspacesResponseDto,
 	})
 	async findMyWorkspaces(
 		@Query() query: WorkspaceQueryDto,
 		@Request() req: any,
-	): Promise<{ workspaces: Workspace[]; total: number }> {
+	): Promise<findUserWorkspacesResponseDto> {
 		return this.workspacesService.findUserWorkspaces(query, req.user.sub);
 	}
 

--- a/src/workspaces/controllers/workspaces.controller.ts
+++ b/src/workspaces/controllers/workspaces.controller.ts
@@ -22,7 +22,7 @@ import { CreateWorkspaceDto } from '../dto/create-workspace.dto';
 import { UpdateWorkspaceDto } from '../dto/update-workspace.dto';
 import { UseInvitationCodeDto } from '../dto/use-invitation-code.dto';
 import { WorkspaceQueryDto } from '../dto/workspace-query.dto';
-import { findMyWorkspacesResponseDto } from '../dto/workspace-response.dto';
+import { findMyWorkspacesResponseDto, WorkspaceCreateResponseDto } from '../dto/workspace-response.dto';
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
 import { WorkspaceRole, WorkspaceUser } from '../entities/workspace-user.entity';
@@ -40,13 +40,17 @@ export class WorkspacesController {
 	@ApiResponse({
 		status: 201,
 		description: '워크스페이스가 성공적으로 생성되었습니다.',
-		type: Workspace,
+		type: WorkspaceCreateResponseDto,
 	})
+	@ApiResponse({ status: 404, description: '사용자를 찾을 수 없습니다.' })
+	@ApiResponse({ status: 409, description: '이미 존재하는 초대 코드입니다.' })
+	@ApiResponse({ status: 403, description: '워크 스페이스에 접근할 권한이 없습니다.' })
+	@ApiResponse({ status: 403, description: '워크스페이스 작업을 수행할 권한이 없습니다.' })
 	@ApiResponse({ status: 400, description: '잘못된 요청입니다.' })
 	async create(
 		@Body() createWorkspaceDto: CreateWorkspaceDto,
 		@Request() req: AuthenticatedRequest, // 👈 타입 명시
-	): Promise<Workspace> {
+	): Promise<WorkspaceCreateResponseDto> {
 		return this.workspacesService.create(createWorkspaceDto, req.user.sub);
 	}
 
@@ -218,7 +222,7 @@ export class WorkspacesController {
 	async getInvitationCodes(
 		@Param('id', ParseIntPipe) id: number,
 		@Request() req: any,
-	): Promise<WorkspaceInvitationCode[]> {
+	): Promise<WorkspaceInvitationCode | null> {
 		return this.workspacesService.getInvitationCodes(id, req.user.sub);
 	}
 

--- a/src/workspaces/dto/workspace-response.dto.ts
+++ b/src/workspaces/dto/workspace-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Workspace } from '../entities/workspace.entity';
+import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
 
 export class findMyWorkspacesResponseDto {
 	@ApiProperty({ type: [Workspace], description: '워크스페이스 목록' })
@@ -8,3 +9,12 @@ export class findMyWorkspacesResponseDto {
 	@ApiProperty({ description: '전체 워크스페이스 수' })
 	total: number;
 }
+
+export class WorkspaceCreateResponseDto {
+	@ApiProperty({ type: Workspace, description: '워크스페이스' })
+	workspace: Workspace;
+
+	@ApiProperty({ description: '초대 코드' })
+	invitationCode: string | null;
+}
+	

--- a/src/workspaces/dto/workspace-response.dto.ts
+++ b/src/workspaces/dto/workspace-response.dto.ts
@@ -18,3 +18,15 @@ export class WorkspaceCreateResponseDto {
 	invitationCode: string | null;
 }
 	
+export class findUserWorkspacesResponseDto {
+	@ApiProperty({ description: '초대 코드가 포함된 워크스페이스 목록' })
+	workspaces: WorkspaceWithActiveInvitationCode[];
+
+	@ApiProperty({ description: '전체 워크스페이스 수' })
+	total: number;
+}
+
+export type WorkspaceWithActiveInvitationCode = Workspace & {
+	activeInvitationCode: string | null;
+}
+	

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -14,6 +14,7 @@ import { InvitationHistory, InvitationStatus } from '../entities/invitation-hist
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
 import { WorkspaceRole, WorkspaceUser } from '../entities/workspace-user.entity';
+import { WorkspaceCreateResponseDto } from '../dto/workspace-response.dto';
 
 @Injectable()
 export class WorkspacesService {
@@ -32,7 +33,7 @@ export class WorkspacesService {
 	/**
 	 * 워크스페이스 생성
 	 */
-	async create(createWorkspaceDto: CreateWorkspaceDto, userId: number): Promise<Workspace> {
+	async create(createWorkspaceDto: CreateWorkspaceDto, userId: number): Promise<WorkspaceCreateResponseDto> {
 		const superAdmin = await this.usersService.findOne(userId);
 		if (!superAdmin) {
 			throw new AppException(ErrorCode.USER_NOT_FOUND);
@@ -54,25 +55,18 @@ export class WorkspacesService {
 		await this.workspaceUserRepository.save(workspaceUser);
 
 		// 초대 코드 생성
-		const code = this.generateInvitationCode();
-		const invitationCode = this.invitationCodeRepository.create({
-			workspaceId: savedWorkspace.id,
-			code,
-		});
-		await this.invitationCodeRepository.save(invitationCode);
+		await this.createInvitationCode(savedWorkspace.id, userId);
 
 		// 활성 초대코드 조회
-		const activeInvitationCode = await this.invitationCodeRepository.findOne({
-			where: { workspaceId: savedWorkspace.id, isActive: true },
-		});
+		const activeInvitationCode = await this.getInvitationCodes(savedWorkspace.id, userId);
 
 		// 워크스페이스 반환 (초대코드는 문자열로)
-		const result = {
-			...savedWorkspace,
+		const result: WorkspaceCreateResponseDto = {
+			workspace: savedWorkspace,
 			invitationCode: activeInvitationCode?.code || null,
 		};
 
-		return result as any;
+		return result;
 	}
 
 	/**
@@ -82,11 +76,6 @@ export class WorkspacesService {
 		query: WorkspaceQueryDto,
 		userId: number,
 	): Promise<{ workspaces: Workspace[]; total: number }> {
-		// const workspaceUsers = await this.workspaceUserRepository.find({
-		// 	where: { userId },
-		// 	relations: ['workspace'],
-		// });
-
 		const { page = 1, limit = 10, search } = query;
 		const skip = (page - 1) * limit;
 
@@ -113,7 +102,6 @@ export class WorkspacesService {
 			.take(limit)
 			.getMany();
 
-		// return workspaceUsers.map((wu) => wu.workspace).filter((w) => w.isActive);
 		return { workspaces, total };
 	}
 
@@ -320,14 +308,15 @@ export class WorkspacesService {
 	async getInvitationCodes(
 		workspaceId: number,
 		userId: number,
-	): Promise<WorkspaceInvitationCode[]> {
+	): Promise<WorkspaceInvitationCode | null> {
 		// 관리자 권한 확인
 		await this.checkUserIsAdmin(userId, workspaceId);
 
-		return this.invitationCodeRepository.find({
-			where: { workspaceId, isActive: true },
-			order: { createdAt: 'DESC' },
+		const invitationCode = await this.invitationCodeRepository.findOne({
+			where: { workspaceId, isActive: true }
 		});
+
+		return invitationCode;
 	}
 
 	/**

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -125,7 +125,7 @@ export class WorkspacesService {
 
 		const workspace = await this.workspaceRepository.findOne({
 			where: { id, isActive: true },
-			relations: ['workspaceUsers', 'workspaceUsers.user'],
+			relations: ['workspaceUsers', 'workspaceUsers.user', 'invitationCodes'],
 		});
 
 		if (!workspace) {

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -205,10 +205,17 @@ export class WorkspacesService {
 
 		const workspace = await this.workspaceRepository.findOne({
 			where: { id, isActive: true, deleted: false },
+			relations: ['invitationCodes'],
 		});
 
 		if (!workspace) {
 			throw new AppException(ErrorCode.WORKSPACE_NOT_FOUND);
+		}
+
+		const invitationCodeId = workspace.invitationCodes.find(code => code.isActive)?.id;
+
+		if (invitationCodeId) {
+			await this.deleteInvitationCode(invitationCodeId, userId);
 		}
 
 		workspace.isActive = false;

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -14,7 +14,7 @@ import { InvitationHistory, InvitationStatus } from '../entities/invitation-hist
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
 import { WorkspaceRole, WorkspaceUser } from '../entities/workspace-user.entity';
-import { WorkspaceCreateResponseDto } from '../dto/workspace-response.dto';
+import { findUserWorkspacesResponseDto, WorkspaceCreateResponseDto, WorkspaceWithActiveInvitationCode } from '../dto/workspace-response.dto';
 
 @Injectable()
 export class WorkspacesService {
@@ -75,16 +75,17 @@ export class WorkspacesService {
 	async findUserWorkspaces(
 		query: WorkspaceQueryDto,
 		userId: number,
-	): Promise<{ workspaces: Workspace[]; total: number }> {
+	): Promise<findUserWorkspacesResponseDto> {
 		const { page = 1, limit = 10, search } = query;
 		const skip = (page - 1) * limit;
 
 		const queryBuilder = this.workspaceRepository
 			.createQueryBuilder('workspace')
 			.leftJoinAndSelect('workspace.workspaceUsers', 'workspaceUsers')
+			.leftJoinAndSelect('workspace.invitationCodes', 'invitationCodes')
 			.where('workspaceUsers.userId = :userId', { userId })
 			.andWhere('workspace.isActive = :isActive', { isActive: true })
-			.andWhere('workspace.deleted = :deleted', { deleted: false });
+			.andWhere('workspace.deleted = :deleted', { deleted: false })
 
 		if (search) {
 			queryBuilder.andWhere(
@@ -96,13 +97,23 @@ export class WorkspacesService {
 		}
 
 		const total = await queryBuilder.getCount();
-		const workspaces = await queryBuilder
+		let workspaces = await queryBuilder
 			.orderBy('workspace.createdAt', 'DESC')
 			.skip(skip)
 			.take(limit)
 			.getMany();
 
-		return { workspaces, total };
+		// 필요하다면 각 워크스페이스에 대해 활성화된 초대 코드만 별도로 처리
+		const workspacesWithActiveInvitationCodes = workspaces.map(workspace => {
+			const activeInvitationCode = workspace.invitationCodes.find(code => code.isActive);
+			return {
+				...workspace,
+				activeInvitationCode: activeInvitationCode?.code || null
+			};
+		});
+
+		return { workspaces: workspacesWithActiveInvitationCodes as WorkspaceWithActiveInvitationCode[], 
+			total };
 	}
 
 	/**


### PR DESCRIPTION
### 수정 사항
- 워크스페이스 생성(create)시 초대 코드 생성 로직을 수정했습니다.
    - 초대 코드 생성 및 조회 메소드가 이미 구현되어 있으므로, 해당 메소드를 사용하도록 수정했습니다.
    - 응답 타입이 조금 변형되어 타입 추가 및 수정 완료했습니다.
- 워크스페이스 조회 관련 메소드들에 초대 코드가 함께 반환되도록 수정했습니다.
    - 응답 타입이 변형되어 타입 추가 및 수정 완료했습니다.
- 워크스페이스 삭제 시 초대 코드도 비활성화 되도록 기능 추가했습니다.