### PR TITLE
Feat: 워크스페이스 조회 로직 및 응답 형식 수정

### DIFF
--- a/src/workspaces/controllers/workspaces.controller.ts
+++ b/src/workspaces/controllers/workspaces.controller.ts
@@ -90,7 +90,7 @@ export class WorkspacesController {
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 정보가 성공적으로 수정되었습니다.',
-		type: Workspace,
+		type: WorkspaceCreateResponseDto,
 	})
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
@@ -98,7 +98,7 @@ export class WorkspacesController {
 		@Param('id', ParseIntPipe) id: number,
 		@Body() updateWorkspaceDto: UpdateWorkspaceDto,
 		@Request() req: any,
-	): Promise<Workspace> {
+	): Promise<WorkspaceCreateResponseDto> {
 		return this.workspacesService.update(id, updateWorkspaceDto, req.user.sub);
 	}
 

--- a/src/workspaces/dto/workspace-response.dto.ts
+++ b/src/workspaces/dto/workspace-response.dto.ts
@@ -28,5 +28,6 @@ export class findUserWorkspacesResponseDto {
 
 export type WorkspaceWithActiveInvitationCode = Workspace & {
 	activeInvitationCode: string | null;
+	userCount: number;
 }
 	

--- a/src/workspaces/dto/workspace-response.dto.ts
+++ b/src/workspaces/dto/workspace-response.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Workspace } from '../entities/workspace.entity';
 import { WorkspaceInvitationCode } from '../entities/workspace-invitation-code.entity';
+import { WorkspaceRole } from '../entities/workspace-user.entity';
 
 export class findMyWorkspacesResponseDto {
 	@ApiProperty({ type: [Workspace], description: '워크스페이스 목록' })
@@ -29,5 +30,6 @@ export class findUserWorkspacesResponseDto {
 export type WorkspaceWithActiveInvitationCode = Workspace & {
 	activeInvitationCode: string | null;
 	userCount: number;
+	userRole?: WorkspaceRole;
 }
 	

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -84,8 +84,23 @@ export class WorkspacesService {
 			.leftJoinAndSelect('workspace.workspaceUsers', 'workspaceUsers')
 			.leftJoinAndSelect('workspace.invitationCodes', 'invitationCodes')
 			.where('workspaceUsers.userId = :userId', { userId })
-			.andWhere('workspace.isActive = :isActive', { isActive: true })
 			.andWhere('workspace.deleted = :deleted', { deleted: false })
+			.andWhere(qb => {
+				// ADMIN 이상 권한을 가진 워크스페이스는 isActive 상관없이 조회
+				// MEMBER 권한만 있는 워크스페이스는 isActive가 true인 것만 조회
+				const subQuery = qb.subQuery()
+					.select('1')
+					.from('workspace_user', 'wu')
+					.where('wu.workspaceId = workspace.id')
+					.andWhere('wu.userId = :userId', { userId })
+					.andWhere('(wu.role = :adminRole OR wu.role = :superAdminRole)', {
+						adminRole: WorkspaceRole.ADMIN,
+						superAdminRole: WorkspaceRole.SUPER_ADMIN
+					})
+					.getQuery();
+
+				return `(workspace.isActive = true OR EXISTS ${subQuery})`;
+			})
 
 		if (search) {
 			queryBuilder.andWhere(
@@ -103,14 +118,20 @@ export class WorkspacesService {
 			.take(limit)
 			.getMany();
 
-		// 필요하다면 각 워크스페이스에 대해 활성화된 초대 코드만 별도로 처리
+		// 각 워크스페이스에 대해 활성화된 초대 코드와 사용자 역할 정보 처리
 		const workspacesWithActiveInvitationCodes = workspaces.map(workspace => {
 			const activeInvitationCode = workspace.invitationCodes.find(code => code.isActive);
 			const userCount = workspace.workspaceUsers.length; // 워크스페이스에 속한 유저 수 계산
+			
+			// 사용자의 해당 워크스페이스에서의 역할 확인
+			const userRole = workspace.workspaceUsers.find(wu => wu.userId === userId)?.role || WorkspaceRole.MEMBER;
+			const isAdmin = userRole === WorkspaceRole.ADMIN || userRole === WorkspaceRole.SUPER_ADMIN;
+			
 			return {
 				...workspace,
 				activeInvitationCode: activeInvitationCode?.code || null,
-				userCount
+				userCount,
+				userRole // 사용자 역할 정보 추가
 			};
 		});
 
@@ -124,9 +145,16 @@ export class WorkspacesService {
 	async findOne(id: number, userId: number): Promise<Workspace> {
 		// 권한 확인하면서 사용자 역할 정보도 가져옴
 		const userInfo = await this.checkPermission(userId, id, WorkspaceRole.MEMBER);
+		
+		// 사용자 역할에 따라 조회 조건 설정
+		// ADMIN 또는 SUPER_ADMIN은 비활성 워크스페이스도 볼 수 있음
+		const isAdmin = userInfo.role === WorkspaceRole.ADMIN || userInfo.role === WorkspaceRole.SUPER_ADMIN;
+		const whereCondition = isAdmin 
+			? { id, deleted: false } 
+			: { id, isActive: true, deleted: false };
 
 		const workspace = await this.workspaceRepository.findOne({
-			where: { id, isActive: true },
+			where: whereCondition,
 			relations: ['workspaceUsers', 'workspaceUsers.user', 'invitationCodes'],
 		});
 

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -144,12 +144,12 @@ export class WorkspacesService {
 		id: number,
 		updateWorkspaceDto: UpdateWorkspaceDto,
 		userId: number,
-	): Promise<Workspace> {
+	): Promise<WorkspaceCreateResponseDto> {
 		// 관리자 권한 확인
 		await this.checkUserIsAdmin(userId, id);
 
 		const workspace = await this.workspaceRepository.findOne({
-			where: { id, isActive: true },
+			where: { id, isActive: true }
 		});
 
 		if (!workspace) {
@@ -157,7 +157,15 @@ export class WorkspacesService {
 		}
 
 		Object.assign(workspace, updateWorkspaceDto);
-		return this.workspaceRepository.save(workspace);
+		const updateWorkspace = await this.workspaceRepository.save(workspace);
+		
+		// 활성 초대코드 찾기
+		const activeInvitationCode = await this.getInvitationCodes(id, userId);
+		
+		return {
+			workspace: updateWorkspace,
+			invitationCode: activeInvitationCode?.code || null,
+		};
 	}
 
 	/**

--- a/src/workspaces/services/workspaces.service.ts
+++ b/src/workspaces/services/workspaces.service.ts
@@ -106,9 +106,11 @@ export class WorkspacesService {
 		// 필요하다면 각 워크스페이스에 대해 활성화된 초대 코드만 별도로 처리
 		const workspacesWithActiveInvitationCodes = workspaces.map(workspace => {
 			const activeInvitationCode = workspace.invitationCodes.find(code => code.isActive);
+			const userCount = workspace.workspaceUsers.length; // 워크스페이스에 속한 유저 수 계산
 			return {
 				...workspace,
-				activeInvitationCode: activeInvitationCode?.code || null
+				activeInvitationCode: activeInvitationCode?.code || null,
+				userCount
 			};
 		});
 


### PR DESCRIPTION
### 수정 사항
- 워크스페이스 조회 시 유저 수도 함께 응답
- 워크스페이스 수정 시 초대코드도 응답에 포함
- 관리자 이상 권한에서 비활성화된 워크스페이스 조회 가능