### PR TITLE
feat: 관리자 권한 개편

### DIFF
--- a/src/auth/guards/workspace-role.guard.ts
+++ b/src/auth/guards/workspace-role.guard.ts
@@ -1,4 +1,10 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import {
+	CanActivate,
+	ExecutionContext,
+	ForbiddenException,
+	Injectable,
+	BadRequestException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -25,13 +31,24 @@ export class WorkspaceRoleGuard implements CanActivate {
 		}
 
 		const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
-		const userId = request.user.sub;
+		const userId = request.user?.sub;
+		if (!userId) {
+			throw new ForbiddenException('인증 정보가 필요합니다.');
+		}
 
-		// URL에서 워크스페이스 ID 추출 (라우트 파라미터에서)
-		const workspaceId = parseInt(request.params.id || request.params.workspaceId);
+		// 명시적 키만 허용: params, query, body 중 workspaceId 찾기
+		const candidate =
+			request.params?.workspaceId ??
+			request.query?.workspaceId ??
+			request.body?.workspaceId ??
+			request.body?.workspace?.id;
 
-		if (!workspaceId) {
-			throw new ForbiddenException('워크스페이스 ID가 필요합니다.');
+		const workspaceId =
+			candidate !== undefined && candidate !== null
+				? Number.parseInt(String(candidate), 10)
+				: NaN;
+		if (Number.isNaN(workspaceId)) {
+			throw new BadRequestException('워크스페이스 ID가 필요합니다.');
 		}
 
 		const workspaceUser = await this.workspaceUserRepository.findOne({
@@ -42,6 +59,10 @@ export class WorkspaceRoleGuard implements CanActivate {
 			throw new ForbiddenException('워크스페이스에 접근할 권한이 없습니다.');
 		}
 
-		return requiredRoles.includes(workspaceUser.role);
+		if (!requiredRoles.includes(workspaceUser.role)) {
+			throw new ForbiddenException('워크스페이스 관리자 권한이 없습니다.');
+		}
+
+		return true;
 	}
 }

--- a/src/groups/controllers/groups.controller.ts
+++ b/src/groups/controllers/groups.controller.ts
@@ -20,6 +20,9 @@ import { UpdateGroupDto } from '../dto/update-group.dto';
 import { Group } from '../entities/group.entity';
 import { GroupRole, GroupUser } from '../entities/group-user.entity';
 import { GroupsService } from '../services/groups.service';
+import { WorkspaceRoles } from '../../auth/decorators/workspace-role.decorator';
+import { WorkspaceRole } from '../../workspaces/entities/workspace-user.entity';
+import { WorkspaceRoleGuard } from '../../auth/guards/workspace-role.guard';
 
 @ApiTags('Groups')
 @ApiBearerAuth()
@@ -30,28 +33,30 @@ export class GroupsController {
 	constructor(private readonly groupsService: GroupsService) {}
 
 	@Post()
-	@ApiOperation({ summary: '그룹 생성' })
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
+	@ApiOperation({ summary: '그룹 생성 (관리자)' })
 	@ApiResponse({
 		status: 201,
 		description: '그룹이 성공적으로 생성됨',
 		type: Group,
 	})
-	@ApiResponse({ status: 400, description: '잘못된 요청 데이터' })
-	@ApiResponse({ status: 403, description: '워크스페이스 멤버가 아님' })
-	@ApiResponse({ status: 401, description: '인증 실패' })
+	@ApiResponse({ status: 400, description: '잘못된 요청 데이터입니다.' })
+	@ApiResponse({ status: 401, description: '사용자 인증 실패' })
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async create(@Body() createGroupDto: CreateGroupDto, @Req() req: AuthenticatedRequest) {
 		return this.groupsService.create(createGroupDto, req.user.sub);
 	}
 
 	@Get()
-	@ApiOperation({ summary: '모든 그룹 조회' })
+	@ApiOperation({ summary: '모든 그룹 조회 (디버그용)' })
 	@ApiResponse({ status: 200, description: '그룹 목록', type: [Group] })
 	findAll(): Promise<Group[]> {
 		return this.groupsService.findAll();
 	}
 
 	@Get('workspace/:workspaceId')
-	@ApiOperation({ summary: '특정 워크스페이스의 그룹 조회' })
+	@ApiOperation({ summary: '특정 워크스페이스의 그룹 조회 (모두)' })
 	@ApiParam({
 		name: 'workspaceId',
 		description: '조회할 워크스페이스의 고유 ID',
@@ -67,28 +72,33 @@ export class GroupsController {
 
 	// 정적 라우트를 동적 라우트보다 먼저 선언
 	@Get('deleted')
-	@ApiOperation({ summary: '삭제된 그룹 목록 조회' })
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
+	@ApiOperation({ summary: '삭제된 그룹 목록 조회 (관리자)' })
 	@ApiResponse({ status: 200, description: '삭제된 그룹 목록', type: [Group] })
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	findDeleted(): Promise<Group[]> {
 		return this.groupsService.findDeleted();
 	}
 
-	@Get(':id')
-	@ApiOperation({ summary: '그룹 상세 조회' })
+	@Get(':groupId')
+	@ApiOperation({ summary: '그룹 상세 조회 (모두)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '조회할 그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
 	@ApiResponse({ status: 200, description: '그룹 상세 정보', type: Group })
-	findOne(@Param('id', ParseIntPipe) id: number): Promise<Group> {
-		return this.groupsService.findOne(id);
+	findOne(@Param('groupId', ParseIntPipe) groupId: number): Promise<Group> {
+		return this.groupsService.findOne(groupId);
 	}
 
-	@Patch(':id')
-	@ApiOperation({ summary: '그룹 수정' })
+	@Patch(':groupId')
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
+	@ApiOperation({ summary: '그룹 수정 (관리자)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '수정할 그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -97,31 +107,35 @@ export class GroupsController {
 		description: '그룹이 성공적으로 수정됨',
 		type: Group,
 	})
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	update(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Body() updateGroupDto: UpdateGroupDto,
 		@Req() req: AuthenticatedRequest,
 	): Promise<Group> {
-		return this.groupsService.update(id, updateGroupDto, req.user.sub);
+		return this.groupsService.update(groupId, updateGroupDto, req.user.sub);
 	}
 
-	@Delete(':id')
-	@ApiOperation({ summary: '그룹 삭제' })
+	@Delete(':groupId')
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
+	@ApiOperation({ summary: '그룹 삭제 (관리자)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '삭제할 그룹의 고유 ID',
 		schema: { type: 'string' },
 	})
 	@ApiResponse({ status: 200, description: '그룹이 성공적으로 삭제됨' })
-	remove(@Param('id') id: string, @Req() req: AuthenticatedRequest): Promise<void> {
-		return this.groupsService.remove(+id, req.user.sub);
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
+	remove(@Param('groupId') groupId: string, @Req() req: AuthenticatedRequest): Promise<void> {
+		return this.groupsService.remove(+groupId, req.user.sub);
 	}
 
 	// 멤버 관련 엔드포인트들
-	@Post(':id/join')
-	@ApiOperation({ summary: '그룹 가입' })
+	@Post(':groupId/join')
+	@ApiOperation({ summary: '그룹 가입 (본인)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '가입할 그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -134,16 +148,16 @@ export class GroupsController {
 	@ApiResponse({ status: 403, description: '가입 권한 없음 (비공개 그룹 등)' })
 	@ApiResponse({ status: 404, description: '그룹을 찾을 수 없음' })
 	joinGroup(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<GroupUser> {
-		return this.groupsService.joinGroup(id, req.user.sub);
+		return this.groupsService.joinGroup(groupId, req.user.sub);
 	}
 
-	@Delete(':id/leave')
-	@ApiOperation({ summary: '그룹 탈퇴' })
+	@Delete(':groupId/leave')
+	@ApiOperation({ summary: '그룹 탈퇴 (본인)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '탈퇴할 그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -152,32 +166,32 @@ export class GroupsController {
 	@ApiResponse({ status: 404, description: '그룹을 찾을 수 없음' })
 	@ApiResponse({ status: 409, description: '그룹 소유자는 탈퇴할 수 없음' })
 	leaveGroup(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.groupsService.leaveGroup(id, req.user.sub);
+		return this.groupsService.leaveGroup(groupId, req.user.sub);
 	}
 
-	@Get(':id/members')
-	@ApiOperation({ summary: '그룹 멤버 목록 조회' })
+	@Get(':groupId/members')
+	@ApiOperation({ summary: '그룹 멤버 목록 조회 (모두)' })
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '멤버 목록을 조회할 그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
 	@ApiResponse({ status: 200, description: '그룹 멤버 목록', type: [GroupUser] })
 	@ApiResponse({ status: 404, description: '그룹을 찾을 수 없음' })
-	getMembers(@Param('id', ParseIntPipe) id: number): Promise<GroupUser[]> {
-		return this.groupsService.getMembers(id);
+	getMembers(@Param('groupId', ParseIntPipe) groupId: number): Promise<GroupUser[]> {
+		return this.groupsService.getMembers(groupId);
 	}
 
-	@Patch(':id/members/:userId/promote')
+	@Patch(':groupId/members/:userId/promote')
 	@ApiOperation({
-		summary: '멤버를 관리자로 승진',
+		summary: '멤버를 관리자로 승진  (미사용)',
 		description: '그룹 관리자가 일반 멤버를 관리자로 승진시킵니다.',
 	})
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '그룹 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -195,20 +209,20 @@ export class GroupsController {
 	@ApiResponse({ status: 403, description: '권한 없음 (관리자 권한 필요)' })
 	@ApiResponse({ status: 404, description: '그룹 또는 멤버를 찾을 수 없음' })
 	promoteToAdmin(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Param('userId', ParseIntPipe) userId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<GroupUser> {
-		return this.groupsService.changeRole(id, userId, GroupRole.ADMIN, req.user.sub);
+		return this.groupsService.changeRole(groupId, userId, GroupRole.ADMIN, req.user.sub);
 	}
 
-	@Patch(':id/members/:userId/demote')
+	@Patch(':groupId/members/:userId/demote')
 	@ApiOperation({
-		summary: '관리자를 일반 멤버로 강등',
+		summary: '관리자를 일반 멤버로 강등 (미사용)',
 		description: '그룹 관리자가 다른 관리자를 일반 멤버로 강등시킵니다.',
 	})
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '그룹 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -226,20 +240,22 @@ export class GroupsController {
 	@ApiResponse({ status: 403, description: '권한 없음 (관리자 권한 필요)' })
 	@ApiResponse({ status: 404, description: '그룹 또는 멤버를 찾을 수 없음' })
 	demoteToMember(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Param('userId', ParseIntPipe) userId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<GroupUser> {
-		return this.groupsService.changeRole(id, userId, GroupRole.MEMBER, req.user.sub);
+		return this.groupsService.changeRole(groupId, userId, GroupRole.MEMBER, req.user.sub);
 	}
 
-	@Post(':id/members/:userId')
+	@Post(':groupId/members/:userId')
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({
 		summary: '관리자가 멤버를 그룹에 추가',
 		description: '그룹 관리자가 특정 사용자를 그룹에 추가합니다.',
 	})
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -254,23 +270,25 @@ export class GroupsController {
 		type: GroupUser,
 	})
 	@ApiResponse({ status: 400, description: '이미 그룹 멤버이거나 잘못된 요청' })
-	@ApiResponse({ status: 403, description: '권한 없음 (관리자 권한 필요)' })
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	@ApiResponse({ status: 404, description: '그룹 또는 사용자를 찾을 수 없음' })
 	addMember(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Param('userId', ParseIntPipe) userId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<GroupUser> {
-		return this.groupsService.addMember(id, userId, req.user.sub);
+		return this.groupsService.addMember(groupId, userId, req.user.sub);
 	}
 
-	@Delete(':id/members/:userId')
+	@Delete(':groupId/members/:userId')
+	@UseGuards(WorkspaceRoleGuard)
+	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({
-		summary: '관리자가 멤버를 그룹에서 제거',
+		summary: '관리자가 멤버를 그룹에서 제거 (관리자)',
 		description: '그룹 관리자가 특정 멤버를 그룹에서 제거합니다.',
 	})
 	@ApiParam({
-		name: 'id',
+		name: 'groupId',
 		description: '그룹의 고유 ID',
 		schema: { type: 'integer', minimum: 1 },
 	})
@@ -281,13 +299,13 @@ export class GroupsController {
 	})
 	@ApiResponse({ status: 200, description: '멤버가 성공적으로 그룹에서 제거됨' })
 	@ApiResponse({ status: 400, description: '자신을 제거할 수 없음' })
-	@ApiResponse({ status: 403, description: '권한 없음 (관리자 권한 필요)' })
+	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	@ApiResponse({ status: 404, description: '그룹 또는 멤버를 찾을 수 없음' })
 	removeMember(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('groupId', ParseIntPipe) groupId: number,
 		@Param('userId', ParseIntPipe) userId: number,
 		@Req() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.groupsService.removeMember(id, userId, req.user.sub);
+		return this.groupsService.removeMember(groupId, userId, req.user.sub);
 	}
 }

--- a/src/groups/entities/group.entity.ts
+++ b/src/groups/entities/group.entity.ts
@@ -22,7 +22,6 @@ export enum GroupType {
 
 @Entity('groups')
 @Index(['workspaceId'])
-@Index(['workspaceId', 'name'], { unique: true }) // 워크스페이스 내 그룹명 중복 방지
 export class Group {
 	@ApiProperty({ description: '그룹 ID' })
 	@PrimaryGeneratedColumn()

--- a/src/workspaces/controllers/workspaces.controller.ts
+++ b/src/workspaces/controllers/workspaces.controller.ts
@@ -77,9 +77,9 @@ export class WorkspacesController {
 		return this.workspacesService.findUserWorkspaces(query, req.user.sub);
 	}
 
-	@Get(':id')
+	@Get(':workspaceId')
 	@ApiOperation({ summary: '워크스페이스 상세 조회' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 정보가 성공적으로 조회되었습니다.',
@@ -88,17 +88,17 @@ export class WorkspacesController {
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스에 접근할 권한이 없습니다.' })
 	async findOne(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<Workspace> {
-		return this.workspacesService.findOne(id, req.user.sub);
+		return this.workspacesService.findOne(workspaceId, req.user.sub);
 	}
 
-	@Patch(':id')
+	@Patch(':workspaceId')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스 정보 수정 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 정보가 성공적으로 수정되었습니다.',
@@ -107,63 +107,63 @@ export class WorkspacesController {
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async update(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Body() updateWorkspaceDto: UpdateWorkspaceDto,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceCreateResponseDto> {
-		return this.workspacesService.update(id, updateWorkspaceDto, req.user.sub);
+		return this.workspacesService.update(workspaceId, updateWorkspaceDto, req.user.sub);
 	}
 
-	@Patch(':id/deactivate')
+	@Patch(':workspaceId/deactivate')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스 비활성화 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '워크스페이스가 성공적으로 비활성화되었습니다.' })
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async deActivate(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.workspacesService.deActivate(id, req.user.sub);
+		return this.workspacesService.deActivate(workspaceId, req.user.sub);
 	}
 
-	@Patch(':id/activate')
+	@Patch(':workspaceId/activate')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스 활성화 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '워크스페이스가 성공적으로 활성화되었습니다.' })
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async activate(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.workspacesService.activate(id, req.user.sub);
+		return this.workspacesService.activate(workspaceId, req.user.sub);
 	}
 
-	@Delete(':id')
+	@Delete(':workspaceId')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.SUPER_ADMIN) // 삭제는 SUPER_ADMIN만
 	@ApiOperation({ summary: '워크스페이스 삭제 (슈퍼관리자 권한 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '워크스페이스가 성공적으로 삭제되었습니다.' })
 	@ApiResponse({ status: 404, description: '워크스페이스를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async remove(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.workspacesService.remove(id, req.user.sub);
+		return this.workspacesService.remove(workspaceId, req.user.sub);
 	}
 
-	@Patch(':id/transfer-super-admin')
+	@Patch(':workspaceId/transfer-super-admin')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스 SUPER_ADMIN 권한 이전 (슈퍼관리자 권한 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 SUPER_ADMIN 권한이 성공적으로 이전되었습니다.',
@@ -178,20 +178,20 @@ export class WorkspacesController {
 		description: '잘못된 요청입니다. (예: 자신에게 위임 시도)',
 	})
 	async transferSuperAdminRole(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Body() transferSuperAdminDto: TransferSuperAdminDto,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
 		return this.workspacesService.transferSuperAdminRole(
-			id,
+			workspaceId,
 			req.user.sub,
 			transferSuperAdminDto.newSuperAdminId,
 		);
 	}
 
-	@Get(':id/users')
+	@Get(':workspaceId/users')
 	@ApiOperation({ summary: '워크스페이스 사용자 목록 조회 (멤버 이상)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 200,
 		description: '워크스페이스 사용자 목록이 성공적으로 조회되었습니다.',
@@ -200,17 +200,17 @@ export class WorkspacesController {
 	@ApiResponse({ status: 403, description: '해당 워크스페이스에 접근할 권한이 없습니다.' })
 	@ApiResponse({ status: 404, description: '해당 워크스페이스를 찾을 수 없습니다.' })
 	async getWorkspaceUsers(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceUser[]> {
-		return this.workspacesService.getWorkspaceUsers(id, req.user.sub);
+		return this.workspacesService.getWorkspaceUsers(workspaceId, req.user.sub);
 	}
 
-	@Post(':id/users')
+	@Post(':workspaceId/users')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스에 사용자 추가 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 201,
 		description: '사용자가 성공적으로 추가되었습니다.',
@@ -220,31 +220,31 @@ export class WorkspacesController {
 	@ApiResponse({ status: 404, description: '추가하려는 사용자를 찾을 수 없습니다.' })
 	@ApiResponse({ status: 409, description: '이미 존재하는 사용자입니다.' })
 	async addUser(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Body() addUserDto: AddUserToWorkspaceDto,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceUser> {
-		return this.workspacesService.addUser(id, addUserDto, req.user.sub);
+		return this.workspacesService.addUser(workspaceId, addUserDto, req.user.sub);
 	}
 
-	@Delete(':id/users/:userId')
+	@Delete(':workspaceId/users/:userId')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스에서 사용자 제거 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiParam({ name: 'userId', description: '제거할 사용자 ID' })
 	@ApiResponse({ status: 200, description: '사용자가 성공적으로 제거되었습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	@ApiResponse({ status: 404, description: '사용자를 찾을 수 없습니다.' })
 	async removeUser(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Param('userId', ParseIntPipe) userId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.workspacesService.removeUser(id, userId, req.user.sub);
+		return this.workspacesService.removeUser(workspaceId, userId, req.user.sub);
 	}
 
-	@Patch(':id/users/role')
+	@Patch(':workspaceId/users/role')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '워크스페이스 사용자 역할 변경 (관리자 이상 권한 필요)' })
@@ -257,23 +257,23 @@ export class WorkspacesController {
 		description: '잘못된 요청입니다. (예: 권한 없는 역할 변경 시도, 자신 역할 변경 시도 등)',
 	})
 	async updateUserRole(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Body() updateWorkspaceUserRoleDto: UpdateWorkspaceUserRoleDto,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
 		return this.workspacesService.updateUserRole(
-			id,
+			workspaceId,
 			updateWorkspaceUserRoleDto.userId,
 			req.user.sub,
 			updateWorkspaceUserRoleDto.role,
 		);
 	}
 
-	@Post(':id/invitation-codes')
+	@Post(':workspaceId/invitation-codes')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '초대 코드 생성 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 201,
 		description: '초대 코드가 성공적으로 생성되었습니다.',
@@ -282,17 +282,17 @@ export class WorkspacesController {
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	@ApiResponse({ status: 409, description: '이미 존재하는 초대 코드입니다.' })
 	async createInvitationCode(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceInvitationCode> {
-		return this.workspacesService.createInvitationCode(id, req.user.sub);
+		return this.workspacesService.createInvitationCode(workspaceId, req.user.sub);
 	}
 
-	@Get(':id/invitation-codes')
+	@Get(':workspaceId/invitation-codes')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '초대 코드 목록 조회 (관리자 권한 이상 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({
 		status: 200,
 		description: '초대 코드 목록이 성공적으로 조회되었습니다.',
@@ -300,24 +300,24 @@ export class WorkspacesController {
 	})
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async getInvitationCodes(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceInvitationCode | null> {
-		return this.workspacesService.getInvitationCodes(id, req.user.sub);
+		return this.workspacesService.getInvitationCodes(workspaceId, req.user.sub);
 	}
 
-	@Put(':id/invitation-codes')
+	@Put(':workspaceId/invitation-codes')
 	@UseGuards(WorkspaceRoleGuard)
 	@WorkspaceRoles(WorkspaceRole.ADMIN, WorkspaceRole.SUPER_ADMIN)
 	@ApiOperation({ summary: '초대 코드 갱신 (관리자 권한 필요)' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '초대 코드가 성공적으로 갱신되었습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 관리자 권한이 없습니다.' })
 	async regenerateInvitationCode(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceInvitationCode> {
-		return this.workspacesService.regenerateInvitationCode(id, req.user.sub);
+		return this.workspacesService.regenerateInvitationCode(workspaceId, req.user.sub);
 	}
 
 	@Delete('invitation-codes/:codeId')
@@ -335,7 +335,7 @@ export class WorkspacesController {
 		return this.workspacesService.deleteInvitationCode(codeId, req.user.sub);
 	}
 
-	@Get(':id/me')
+	@Get(':workspaceId/me')
 	@ApiOperation({ summary: '내 정보 조회' })
 	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
 	@ApiResponse({
@@ -345,33 +345,33 @@ export class WorkspacesController {
 	})
 	@ApiResponse({ status: 403, description: '워크스페이스 권한이 없습니다.' })
 	async getMyInfo(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<WorkspaceUser | null> {
-		return this.workspacesService.getMyWorkspaceInfo(id, req.user.sub);
+		return this.workspacesService.getMyWorkspaceInfo(workspaceId, req.user.sub);
 	}
 
-	@Patch(':id/me')
+	@Patch(':workspaceId/me')
 	@ApiOperation({ summary: '내 워크스페이스 정보 수정' })
 	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '내 정보가 성공적으로 수정되었습니다.' })
 	@ApiResponse({ status: 403, description: '워크스페이스 권한이 없습니다.' })
 	@ApiResponse({ status: 404, description: '사용자를 찾을 수 없습니다.' })
 	async updateMyInfo(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Body() updateWorkspaceUserDto: UpdateWorkspaceUserDto,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
 		return this.workspacesService.updateMyWorkspaceInfo(
-			id,
+			workspaceId,
 			req.user.sub,
 			updateWorkspaceUserDto,
 		);
 	}
 
-	@Delete(':id/leave')
+	@Delete(':workspaceId/leave')
 	@ApiOperation({ summary: '워크스페이스 나가기' })
-	@ApiParam({ name: 'id', description: '워크스페이스 ID' })
+	@ApiParam({ name: 'workspaceId', description: '워크스페이스 ID' })
 	@ApiResponse({ status: 200, description: '워크스페이스에서 성공적으로 나갔습니다.' })
 	@ApiResponse({
 		status: 403,
@@ -379,10 +379,10 @@ export class WorkspacesController {
 	})
 	@ApiResponse({ status: 404, description: '워크스페이스 또는 사용자를 찾을 수 없습니다.' })
 	async leaveWorkspace(
-		@Param('id', ParseIntPipe) id: number,
+		@Param('workspaceId', ParseIntPipe) workspaceId: number,
 		@Request() req: AuthenticatedRequest,
 	): Promise<void> {
-		return this.workspacesService.leaveWorkspace(id, req.user.sub);
+		return this.workspacesService.leaveWorkspace(workspaceId, req.user.sub);
 	}
 
 	@Post('join')


### PR DESCRIPTION
- 그룹 관리자 삭제
- 워크스페이스 관리자가 그룹도 관리
- workspaceRoleGuard가 그룹과 워크스페이스에서 모두 동작하고 충돌하지 않기 위해 url, param, body에서 모두 탐색 및 컨트롤러에서 url 파라미터 이름을 workspace, group 인지 명시