### PR TITLE
Feat: UTC와 한국 시간 일관성 문제 수정

### DIFF
--- a/src/common/utils/time.util.ts
+++ b/src/common/utils/time.util.ts
@@ -81,3 +81,34 @@ export function convertDatesToKoreanTime<T>(obj: T, visited = new WeakMap()): T 
 
 	return obj;
 }
+
+/**
+ * 한국 시간대 기준으로 특정 날짜의 특정 시간을 생성
+ * @param date 기준 날짜 (YYYY-MM-DD 형식)
+ * @param hour 시간 (0-23)
+ * @param minute 분 (0-59)
+ * @param second 초 (0-59)
+ * @param millisecond 밀리초 (0-999)
+ * @returns 한국 시간대 기준 Date 객체
+ */
+export function createKoreanDateTime(
+	date: string | Date,
+	hour: number = 0,
+	minute: number = 0,
+	second: number = 0,
+	millisecond: number = 0
+): Date {
+	const targetDate = typeof date === 'string' ? new Date(date) : date;
+	
+	// 한국 시간대(UTC+9) 기준으로 시간 생성
+	const koreanTime = new Date();
+	koreanTime.setUTCFullYear(targetDate.getFullYear());
+	koreanTime.setUTCMonth(targetDate.getMonth());
+	koreanTime.setUTCDate(targetDate.getDate());
+	koreanTime.setUTCHours(hour - 9); // UTC로 변환 (한국시간 - 9시간)
+	koreanTime.setUTCMinutes(minute);
+	koreanTime.setUTCSeconds(second);
+	koreanTime.setUTCMilliseconds(millisecond);
+	
+	return koreanTime;
+}

--- a/src/reservations/services/reservations.service.ts
+++ b/src/reservations/services/reservations.service.ts
@@ -12,6 +12,7 @@ import { ReservationQueryDto } from '../dto/reservation-query.dto';
 import { UpdateReservationDto } from '../dto/update-reservation.dto';
 import { Reservation, ReservationStatus } from '../entities/reservation.entity';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { createKoreanDateTime } from '../../common/utils/time.util';
 
 @Injectable()
 export class ReservationsService {
@@ -396,10 +397,8 @@ export class ReservationsService {
 		await this.checkUserInWorkspace(userId, space.workspaceId);
 
 		const targetDate = new Date(date);
-		const startOfDay = new Date(targetDate);
-		startOfDay.setHours(0, 0, 0, 0);
-		const endOfDay = new Date(targetDate);
-		endOfDay.setHours(23, 59, 59, 999);
+		const startOfDay = createKoreanDateTime(targetDate, 9, 0, 0);
+		const endOfDay = createKoreanDateTime(targetDate, 18, 0, 0);
 
 		// 해당 날짜의 예약된 시간 조회
 		const reservations = await this.reservationRepository.find({
@@ -426,16 +425,9 @@ export class ReservationsService {
 			...unavailableTimes.map((u) => ({ startTime: u.startTime, endTime: u.endTime })),
 		].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
 
-		// 가능한 시간대 계산 (9:00 - 18:00 기준)
-		const workingHours = {
-			start: new Date(targetDate),
-			end: new Date(targetDate),
-		};
-		workingHours.start.setHours(9, 0, 0, 0);
-		workingHours.end.setHours(18, 0, 0, 0);
-
+		// 가능한 시간대 계산
 		const availableSlots: Array<{ startTime: Date; endTime: Date }> = [];
-		let currentTime = workingHours.start;
+		let currentTime = startOfDay;
 
 		for (const blockedTime of blockedTimes) {
 			if (currentTime < blockedTime.startTime) {
@@ -448,10 +440,10 @@ export class ReservationsService {
 		}
 
 		// 마지막 블록 이후 남은 시간
-		if (currentTime < workingHours.end) {
+		if (currentTime < endOfDay) {
 			availableSlots.push({
 				startTime: new Date(currentTime),
-				endTime: new Date(workingHours.end),
+				endTime: new Date(endOfDay),
 			});
 		}
 
@@ -465,7 +457,7 @@ export class ReservationsService {
     @Cron('0,30 0-9 * * *')
     async markCompletedReservations(): Promise<void> {
         try {
-            const now = new Date();
+            const now = createKoreanDateTime(new Date(), 0, 0, 0);
             
             const result = await this.reservationRepository.update(
                 {


### PR DESCRIPTION
- `Date()`객체는 UTC기준으로 시간을 생성하지만, 그 하위 메소드는 로컬 시간 기준으로 동작하는 원인으로 인해 시간 정합성에 문제가 발생
- 일관되게 동작하도록 수정해 반영